### PR TITLE
feat: add project management endpoints for dashboard integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ import alignmentRoutes from "./src/routes/alignment.routes.js"; // <-- NUEVO
 import reportsRoutes from "./src/routes/report.routes.js";
 import path from "path";  
 import rootDashboardRoutes from "./src/routes/dashboard.routes.js";
+import projectRoutes from "./src/routes/project.routes.js";
+import reportSearchRoutes from "./src/routes/reportSearch.routes.js";
 const app = express();
 
 app.use(morgan("dev"));
@@ -28,7 +30,9 @@ app.use(cors({
 app.use(passport.initialize());
 
 // Rutas
-app.use("/", rootDashboardRoutes); // <-- ahora /stats y /projects/recent existen en raíz
+app.use("/", rootDashboardRoutes); // <-- ahora /stats existe en raíz
+app.use("/projects", projectRoutes);
+app.use("/reports", reportSearchRoutes);
 
 app.use("/auth", authRoutes);
 app.use("/api", userRoutes);

--- a/src/models/project.model.js
+++ b/src/models/project.model.js
@@ -1,0 +1,126 @@
+import { pool } from '../config/db.js';
+
+function parseJSON(value) {
+  if (!value) return undefined;
+  if (typeof value === 'object') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeLikePattern(text = '') {
+  return `%${text.replace(/[ %_]/g, (char) => (char === ' ' ? '%' : `\\${char}`))}%`;
+}
+
+export function mapProjectRow(row) {
+  if (!row) return null;
+
+  const created = row.created_at ? new Date(row.created_at) : null;
+  const updated = row.updated_at ? new Date(row.updated_at) : created;
+  const lastCalc = row.last_calculation_at ? new Date(row.last_calculation_at) : null;
+  const metrics = parseJSON(row.metrics);
+
+  const base = {
+    id: row.id,
+    projectId: row.id,
+    name: row.name,
+    title: row.name,
+    description: row.description,
+    status: row.status || row.state || 'NEW',
+    state: row.status || row.state || 'NEW',
+    createdAt: created ? created.toISOString() : null,
+    created_at: created ? created.toISOString() : null,
+    updatedAt: updated ? updated.toISOString() : null,
+    updated_at: updated ? updated.toISOString() : null,
+  };
+
+  if (lastCalc) {
+    base.lastCalculationAt = lastCalc.toISOString();
+    base.last_calculation_at = lastCalc.toISOString();
+  }
+
+  if (row.progress !== undefined && row.progress !== null) {
+    base.progress = Number(row.progress);
+  }
+
+  let precision = undefined;
+  if (row.precision_score !== undefined && row.precision_score !== null) {
+    precision = Number(row.precision_score);
+    base.precision = precision;
+  }
+
+  if (metrics || precision !== undefined) {
+    base.metrics = { ...(metrics || {}) };
+    if (precision !== undefined && base.metrics.precision === undefined) {
+      base.metrics.precision = precision;
+    }
+  }
+
+  return base;
+}
+
+export async function createProject({ name, description }) {
+  const trimmedName = name.trim();
+  const trimmedDescription = description ? description.trim() : '';
+  const normalizedDescription = trimmedDescription ? trimmedDescription : null;
+
+  const [result] = await pool.query(
+    `INSERT INTO projects (name, description, status)
+     VALUES (?, ?, 'NEW')`,
+    [trimmedName, normalizedDescription]
+  );
+
+  return findProjectById(result.insertId);
+}
+
+export async function findProjectById(id) {
+  const [rows] = await pool.query(`SELECT * FROM projects WHERE id = ?`, [id]);
+  if (!rows.length) return null;
+  return mapProjectRow(rows[0]);
+}
+
+export async function listRecentProjects(limit = 5) {
+  const [rows] = await pool.query(
+    `SELECT *
+     FROM projects
+     ORDER BY COALESCE(updated_at, created_at) DESC
+     LIMIT ?`,
+    [limit]
+  );
+  return rows.map(mapProjectRow);
+}
+
+export async function searchProjects(query, limit = 10) {
+  const normalized = query.trim();
+  if (!normalized) return [];
+
+  const like = escapeLikePattern(normalized);
+  const maybeId = Number.parseInt(normalized, 10);
+  const conditions = [];
+  const params = [];
+
+  if (!Number.isNaN(maybeId)) {
+    conditions.push('id = ?');
+    params.push(maybeId);
+  }
+
+  conditions.push('name LIKE ?');
+  params.push(like);
+
+  conditions.push('description LIKE ?');
+  params.push(like);
+
+  const sql = `
+    SELECT *
+    FROM projects
+    WHERE ${conditions.join(' OR ')}
+    ORDER BY COALESCE(updated_at, created_at) DESC
+    LIMIT ?
+  `;
+  params.push(limit);
+
+  const [rows] = await pool.query(sql, params);
+  return rows.map(mapProjectRow);
+}

--- a/src/routes/dashboard.routes.js
+++ b/src/routes/dashboard.routes.js
@@ -1,36 +1,12 @@
 import { Router } from 'express';
 import { pool } from '../config/db.js';
+import { precisionPctContinuous, SELECT_RESULTS_FIELDS } from '../utils/precision.js';
 
 const router = Router();
 
-// ====== Config precisión continua ======
-const TOL = { VN: 10, VF: 10, HN: 50, HF: 150 };
-function precisionPctContinuous({ VN, VF, HN, HF }) {
-  const parts = [['VN', VN], ['VF', VF], ['HN', HN], ['HF', HF]]
-    .filter(([, v]) => typeof v === 'number' && !Number.isNaN(v));
-  if (!parts.length) return 0;
-  const scores = parts.map(([k, v]) => {
-    const lim = TOL[k];
-    if (!lim || !isFinite(lim) || lim <= 0) return 0;
-    const rel = Math.abs(v) / lim;
-    const score = Math.max(0, 1 - Math.min(1, rel));
-    return score;
-  });
-  const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
-  return +(avg * 100).toFixed(1);
-}
-
-// Utilidad para leer VN,VF,HN,HF desde JSON (MariaDB/MySQL 5.7+)
-const SELECT_RESULTS_FIELDS = `
-  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.VN')) AS DECIMAL(20,6)) AS VN,
-  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.VF')) AS DECIMAL(20,6)) AS VF,
-  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.HN')) AS DECIMAL(20,6)) AS HN,
-  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.HF')) AS DECIMAL(20,6)) AS HF
-`;
-
 /**
  * GET /stats
- * - activeProjects: equipos distintos en últimos 7 días
+ * - activeProjects: proyectos con actividad en los últimos 7 días
  * - totalCalculations: total de alignment_reports
  * - generatedReports: total de alignment_reports (igual por ahora)
  * - avgAccuracy: precisión continua promedio (todos los registros)
@@ -41,17 +17,7 @@ router.get('/stats', async (req, res) => {
     // Totales globales
     const [[tot]] = await pool.query(`SELECT COUNT(*) AS total FROM alignment_reports`);
     const totalCalculations = Number(tot.total || 0);
-    const generatedReports  = totalCalculations;
-
-    // Activos: últimos 7 días
-    const [[act]] = await pool.query(`
-      SELECT COUNT(DISTINCT equipment_id) AS active
-      FROM alignment_reports
-      WHERE equipment_id IS NOT NULL
-        AND TRIM(equipment_id) <> ''
-        AND created_at >= (NOW() - INTERVAL 7 DAY)
-    `);
-    const activeProjects = Number(act.active || 0);
+    const generatedReports = totalCalculations;
 
     // Precisión promedio global (continua)
     const [allRows] = await pool.query(`
@@ -59,7 +25,9 @@ router.get('/stats', async (req, res) => {
       FROM alignment_reports
     `);
     const allPcts = allRows.map(precisionPctContinuous);
-    const avgAccuracy = allPcts.length ? +(allPcts.reduce((a,b)=>a+b,0)/allPcts.length).toFixed(1) : 0;
+    const avgAccuracy = allPcts.length
+      ? +(allPcts.reduce((a, b) => a + b, 0) / allPcts.length).toFixed(1)
+      : 0;
 
     // ====== DELTAS semana actual vs semana previa ======
     const [curRows] = await pool.query(`
@@ -74,8 +42,12 @@ router.get('/stats', async (req, res) => {
         AND created_at >= (NOW() - INTERVAL 14 DAY)
     `);
 
-    const curActive  = new Set(curRows.filter(r => (r.equipment_id||'').trim()).map(r => r.equipment_id)).size;
-    const prevActive = new Set(prevRows.filter(r => (r.equipment_id||'').trim()).map(r => r.equipment_id)).size;
+    const curActive = new Set(
+      curRows.filter((r) => (r.equipment_id || '').trim()).map((r) => r.equipment_id)
+    ).size;
+    const prevActive = new Set(
+      prevRows.filter((r) => (r.equipment_id || '').trim()).map((r) => r.equipment_id)
+    ).size;
 
     const curCalc = curRows.length;
     const prevCalc = prevRows.length;
@@ -85,64 +57,48 @@ router.get('/stats', async (req, res) => {
     const prevReports = prevCalc;
 
     const curAcc = curRows.length
-      ? +(curRows.map(precisionPctContinuous).reduce((a,b)=>a+b,0)/curRows.length).toFixed(1)
+      ? +(curRows.map(precisionPctContinuous).reduce((a, b) => a + b, 0) / curRows.length).toFixed(1)
       : 0;
     const prevAcc = prevRows.length
-      ? +(prevRows.map(precisionPctContinuous).reduce((a,b)=>a+b,0)/prevRows.length).toFixed(1)
+      ? +(prevRows.map(precisionPctContinuous).reduce((a, b) => a + b, 0) / prevRows.length).toFixed(1)
       : 0;
 
+    let activeProjects = curActive;
+    let projectDelta = curActive - prevActive;
+
+    try {
+      const [[currentProjects]] = await pool.query(`
+        SELECT COUNT(*) AS total
+        FROM projects
+        WHERE updated_at >= (NOW() - INTERVAL 7 DAY)
+      `);
+      const [[previousProjects]] = await pool.query(`
+        SELECT COUNT(*) AS total
+        FROM projects
+        WHERE updated_at <  (NOW() - INTERVAL 7 DAY)
+          AND updated_at >= (NOW() - INTERVAL 14 DAY)
+      `);
+
+      activeProjects = Number(currentProjects.total || 0);
+      projectDelta = activeProjects - Number(previousProjects.total || 0);
+    } catch (err) {
+      if (err.code !== 'ER_NO_SUCH_TABLE') {
+        throw err;
+      }
+      // Si la tabla projects no existe todavía, usamos el fallback basado en alignment_reports
+    }
+
     const deltas = {
-      projects:      curActive  - prevActive,
-      calculations:  curCalc    - prevCalc,
-      reports:       curReports - prevReports,
-      accuracy:      +(curAcc - prevAcc).toFixed(1),
+      projects: projectDelta,
+      calculations: curCalc - prevCalc,
+      reports: curReports - prevReports,
+      accuracy: +(curAcc - prevAcc).toFixed(1),
     };
 
     res.json({ activeProjects, totalCalculations, generatedReports, avgAccuracy, deltas });
   } catch (e) {
     console.error('GET /stats error:', e);
     res.status(500).json({ error: 'No se pudo obtener stats' });
-  }
-});
-router.get('/projects/recent', async (req, res) => {
-  try {
-    const [rows] = await pool.query(`
-      SELECT
-        id, title, equipment_id, description, created_at,
-        ${SELECT_RESULTS_FIELDS}
-      FROM alignment_reports
-      ORDER BY created_at DESC
-      LIMIT 5
-    `);
-
-    const now = Date.now();
-    const twoDays = 2 * 24 * 3600 * 1000;
-
-    const mapped = rows.map(r => {
-      const name =
-        (r.title && r.title.trim()) ||
-        (r.equipment_id && r.equipment_id.trim()) ||
-        `Reporte #${r.id}`;
-
-      let status = 'PENDIENTE';
-      if (r.title || r.description) status = 'COMPLETADO';
-      else if (now - new Date(r.created_at).getTime() <= twoDays) status = 'EN_PROGRESO';
-
-      const precision = precisionPctContinuous(r); // continua 0..100
-
-      return {
-        id: r.id,
-        name,
-        status,
-        updatedAt: new Date(r.created_at).toISOString(),
-        precision,
-      };
-    });
-
-    res.json(mapped);
-  } catch (e) {
-    console.error('GET /projects/recent error:', e);
-    res.status(500).json({ error: 'No se pudo obtener proyectos recientes' });
   }
 });
 

--- a/src/routes/project.routes.js
+++ b/src/routes/project.routes.js
@@ -1,0 +1,132 @@
+import { Router } from 'express';
+import { pool } from '../config/db.js';
+import { requireAuth } from '../middlewares/requireAuth.js';
+import {
+  createProject,
+  listRecentProjects,
+  searchProjects,
+} from '../models/project.model.js';
+import { precisionPctContinuous, SELECT_RESULTS_FIELDS } from '../utils/precision.js';
+
+const router = Router();
+
+router.post('/', requireAuth, async (req, res) => {
+  const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+  const description = typeof req.body?.description === 'string' ? req.body.description : '';
+
+  if (!name) {
+    return res.status(400).json({ error: 'El nombre del proyecto es obligatorio' });
+  }
+
+  try {
+    const project = await createProject({ name, description });
+    if (!project) {
+      return res.status(500).json({ error: 'No se pudo crear el proyecto' });
+    }
+    return res.status(201).json({ project });
+  } catch (error) {
+    console.error('POST /projects error:', error);
+    if (error.code === 'ER_NO_SUCH_TABLE') {
+      return res.status(500).json({
+        error: 'Tabla "projects" inexistente',
+        hint: 'Ejecuta la migración/creación de tabla antes de crear proyectos',
+      });
+    }
+    return res.status(500).json({ error: 'No se pudo crear el proyecto' });
+  }
+});
+
+router.get('/search', async (req, res) => {
+  const query = typeof req.query.q === 'string' ? req.query.q : '';
+  const limitParam = Number.parseInt(req.query.limit, 10);
+  const limit = Number.isNaN(limitParam) ? 10 : Math.min(Math.max(limitParam, 1), 50);
+
+  if (!query.trim()) {
+    return res.json({ items: [] });
+  }
+
+  try {
+    const items = await searchProjects(query, limit);
+    return res.json({ items });
+  } catch (error) {
+    if (error.code === 'ER_NO_SUCH_TABLE') {
+      return res.json({ items: [] });
+    }
+    console.error('GET /projects/search error:', error);
+    return res.status(500).json({ error: 'No se pudo buscar proyectos' });
+  }
+});
+
+router.get('/recent', async (req, res) => {
+  const limitParam = Number.parseInt(req.query.limit, 10);
+  const limit = Number.isNaN(limitParam) ? 5 : Math.min(Math.max(limitParam, 1), 50);
+
+  try {
+    const recent = await listRecentProjects(limit);
+    if (recent.length) {
+      return res.json(recent);
+    }
+  } catch (error) {
+    if (error.code !== 'ER_NO_SUCH_TABLE') {
+      console.error('GET /projects/recent error:', error);
+      return res.status(500).json({ error: 'No se pudo obtener proyectos recientes' });
+    }
+    // Si la tabla no existe seguimos con el fallback usando alignment_reports
+  }
+
+  try {
+    const [rows] = await pool.query(
+      `SELECT
+         id,
+         title,
+         equipment_id,
+         description,
+         created_at,
+         ${SELECT_RESULTS_FIELDS}
+       FROM alignment_reports
+       ORDER BY created_at DESC
+       LIMIT ?`,
+      [limit]
+    );
+
+    const now = Date.now();
+    const twoDays = 2 * 24 * 3600 * 1000;
+
+    const mapped = rows.map((row) => {
+      const name =
+        (row.title && row.title.trim()) ||
+        (row.equipment_id && row.equipment_id.trim()) ||
+        `Reporte #${row.id}`;
+
+      let status = 'PENDIENTE';
+      if (row.title || row.description) status = 'COMPLETADO';
+      else if (now - new Date(row.created_at).getTime() <= twoDays) status = 'EN_PROGRESO';
+
+      const updatedISO = new Date(row.created_at).toISOString();
+      const precision = precisionPctContinuous(row);
+
+      return {
+        id: row.id,
+        projectId: row.id,
+        name,
+        title: name,
+        status,
+        state: status,
+        description: row.description,
+        createdAt: updatedISO,
+        created_at: updatedISO,
+        updatedAt: updatedISO,
+        updated_at: updatedISO,
+        precision,
+        metrics: { precision },
+      };
+    });
+
+    return res.json(mapped);
+  } catch (error) {
+    console.error('GET /projects/recent fallback error:', error);
+    return res.status(500).json({ error: 'No se pudo obtener proyectos recientes' });
+  }
+});
+
+export default router;

--- a/src/routes/reportSearch.routes.js
+++ b/src/routes/reportSearch.routes.js
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { pool } from '../config/db.js';
+
+const router = Router();
+
+function buildLike(query) {
+  return `%${query.replace(/[%_]/g, (char) => `\\${char}`)}%`;
+}
+
+router.get('/search', async (req, res) => {
+  const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const limitParam = Number.parseInt(req.query.limit, 10);
+  const limit = Number.isNaN(limitParam) ? 10 : Math.min(Math.max(limitParam, 1), 50);
+
+  if (!query) {
+    return res.json({ items: [] });
+  }
+
+  const like = buildLike(query);
+  const maybeId = Number.parseInt(query, 10);
+
+  try {
+    const params = [like, like, like, like, limit];
+    let sql = `
+      SELECT id, title, method, type, description, equipment_id, created_at
+      FROM alignment_reports
+      WHERE title LIKE ?
+         OR equipment_id LIKE ?
+         OR method LIKE ?
+         OR description LIKE ?
+    `;
+
+    if (!Number.isNaN(maybeId)) {
+      sql += ' OR id = ?';
+      params.splice(params.length - 1, 0, maybeId);
+    }
+
+    sql += ' ORDER BY created_at DESC LIMIT ?';
+
+    const [rows] = await pool.query(sql, params);
+
+    const items = rows.map((row) => {
+      const createdISO = row.created_at ? new Date(row.created_at).toISOString() : null;
+      const title = (row.title && row.title.trim()) || `Reporte #${row.id}`;
+      const method = row.method || row.type || 'DESCONOCIDO';
+
+      return {
+        id: row.id,
+        reportId: row.id,
+        title,
+        name: title,
+        method,
+        type: row.type || method,
+        createdAt: createdISO,
+        created_at: createdISO,
+      };
+    });
+
+    return res.json({ items });
+  } catch (error) {
+    console.error('GET /reports/search error:', error);
+    return res.status(500).json({ error: 'No se pudo buscar reportes' });
+  }
+});
+
+export default router;

--- a/src/utils/precision.js
+++ b/src/utils/precision.js
@@ -1,0 +1,30 @@
+const TOL = { VN: 10, VF: 10, HN: 50, HF: 150 };
+
+export const SELECT_RESULTS_FIELDS = `
+  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.VN')) AS DECIMAL(20,6)) AS VN,
+  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.VF')) AS DECIMAL(20,6)) AS VF,
+  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.HN')) AS DECIMAL(20,6)) AS HN,
+  CAST(JSON_UNQUOTE(JSON_EXTRACT(results, '$.HF')) AS DECIMAL(20,6)) AS HF
+`;
+
+export function precisionPctContinuous({ VN, VF, HN, HF }) {
+  const parts = [
+    ['VN', VN],
+    ['VF', VF],
+    ['HN', HN],
+    ['HF', HF],
+  ].filter(([, v]) => typeof v === 'number' && !Number.isNaN(v));
+
+  if (!parts.length) return 0;
+
+  const scores = parts.map(([key, value]) => {
+    const limit = TOL[key];
+    if (!limit || !isFinite(limit) || limit <= 0) return 0;
+    const relative = Math.abs(value) / limit;
+    const score = Math.max(0, 1 - Math.min(1, relative));
+    return score;
+  });
+
+  const average = scores.reduce((acc, score) => acc + score, 0) / scores.length;
+  return +(average * 100).toFixed(1);
+}


### PR DESCRIPTION
## Summary
- expose `/projects` endpoints to create projects, list recent activity, and serve project search results expected by the dashboard
- add `/reports/search` endpoint and share precision utilities used by dashboard metrics
- update dashboard stats to prefer the new projects table while keeping alignment report fallbacks

## Testing
- node --check src/utils/precision.js
- node --check src/models/project.model.js
- node --check src/routes/project.routes.js
- node --check src/routes/reportSearch.routes.js
- node --check src/routes/dashboard.routes.js

------
https://chatgpt.com/codex/tasks/task_e_68dcc290593c8328b77756170e2ca818